### PR TITLE
Fix `Discord ID` –> `Discord UID` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This bot integrates with an Airtable base to store and manage data. The base sho
 - `Users` table
   - `Username`: Single line text
   - `Record ID`: Formula, `RECORD_ID()` (optional)
-  - `Discord ID`: Single line text
+  - `Discord UID`: Single line text
   - `Avatar`: Attachment,
   - `GitHub User`: Single line text (not implemented yet)
   - `Website`: Single line text (not implemented yet)


### PR DESCRIPTION
I was setting this bot up for Purdue Hackers :) and initially it crashed because it was trying to filter for the `Discord UID` field, but the field is actually called `Discord ID`. This PR updates the README to reflect the correct user field.