### PR TITLE
Use `cleanContent` property

### DIFF
--- a/src/scrapbook.js
+++ b/src/scrapbook.js
@@ -1,3 +1,4 @@
+import { cleanContent } from 'discord.js'
 import ShortUniqueId from 'short-unique-id';
 import base from './base.js';
 
@@ -50,7 +51,7 @@ function uploadScrap(discordUid, message, threadChannelId) {
         fields: {
           "Discord Message ID": message.id,
           "Discord Thread ID": threadChannelId,
-          "Description": message.content,
+          "Description": cleanContent(message.content, message),
           "Attachments": message.attachments.map(a => {
             return { url: a.url };
           }),


### PR DESCRIPTION
I was using this in a meeting and found that whenever someone messages a channel or username, it uploads the raw ID. (e.g. "Hi <#93029398409824>")

This PR uses the `cleanContent` function from discord.js to instead send the raw content.